### PR TITLE
Convert html object to string when assigned to content_page

### DIFF
--- a/iubenda-cookie-class/iubenda.class.php
+++ b/iubenda-cookie-class/iubenda.class.php
@@ -215,7 +215,7 @@
 						}
 					}
 				}
-				$this->content_page = $html;
+				$this->content_page = $html->__toString();
 			}
 		}
 
@@ -241,7 +241,7 @@
 						}
 					}
 				}
-				$this->content_page = $html;
+				$this->content_page = $html->__toString();
 			}
 		}
 		


### PR DESCRIPTION
I had issues with this plugin and some kind of contents. For example a wordpress plugin who should return a json content, with this plugin enabled return a blank content.
The issue happen because, for some reason, the $html object assigned to $this->content_page is not handled as a string. Forcing the string conversion during the assignment fix the problem.

Hope this can be merged into the main repository.

Thanks
